### PR TITLE
Fix inventory overflow crash

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,6 +1,5 @@
 require("prototypes.function")
 
-
 local WORM = "big-sandworm"
 
 local function already_attacked(surface, position, radius)
@@ -41,8 +40,7 @@ script.on_nth_tick(1200, function()
                         y = chunk_position.y + math.sin(angle) * ATTACK_DISTANCE
                     }
 
-                    local directions = { defines.direction.west, defines.direction.north, defines.direction.east, defines
-                        .direction.south }
+                    local directions = { defines.direction.west, defines.direction.north, defines.direction.east, defines.direction.south }
                     local dir_index = math.floor((angle + math.pi / 4) / (math.pi / 2)) % 4 + 1
 
                     log(angle)
@@ -105,8 +103,7 @@ local function find_spice_blow_positions(surface, chance_per_chunk)
 
             for _, player in pairs(game.players) do
                 if player.surface == surface then
-                    player.add_custom_alert(blow_pos, { type = "item", name = "spice" }, { "", "Spice Blow immanent" },
-                        true)
+                    player.add_custom_alert(blow_pos, { type = "item", name = "spice" }, { "", "Spice Blow immanent" }, true)
                 end
             end
 
@@ -297,7 +294,7 @@ script.on_event(defines.events.on_pre_player_mined_item, function(event)
                                 }
                             end
                             if type(inserted) == "number" and inserted < content.count then
-                                surface.spill_item_stack({ position = player.position, stack = { name = content.name, count = content.count - inserted } })
+                                surface.spill_item_stack({ position = player.position, stack = { name = content.name, count = content.count - inserted, quality = content.quality } })
                             end
                         end
                     end

--- a/control.lua
+++ b/control.lua
@@ -4,20 +4,20 @@ require("prototypes.function")
 local WORM = "big-sandworm"
 
 local function already_attacked(surface, position, radius)
-    local worms = surface.find_entities_filtered{name=WORM}
+    local worms = surface.find_entities_filtered { name = WORM }
 
     if table_size(worms) == 0 then
         return false
     end
 
     for _, worm in pairs(worms) do
-        if distance(position, worm.position) < radius then 
+        if distance(position, worm.position) < radius then
             return true
         end
     end
 
     return false
-end 
+end
 
 local POLLUTION_THRESHOLD = 15
 local ATTACK_DISTANCE = 90
@@ -26,22 +26,23 @@ local worm_brain = {}
 
 script.on_nth_tick(1200, function()
     if game.surfaces["arrakis"] then
-        arrakis = game.surfaces["arrakis"] 
+        arrakis = game.surfaces["arrakis"]
         for chunk in arrakis.get_chunks() do
-            local chunk_position = {x = chunk.x*32, y = chunk.y*32}
+            local chunk_position = { x = chunk.x * 32, y = chunk.y * 32 }
             local pollution = arrakis.get_pollution(chunk_position)
-            
+
             if pollution > POLLUTION_THRESHOLD then
                 if not already_attacked(arrakis, chunk_position, 125) then
                     -- direction from where the worm comes from
                     local angle = math.random() * 2 * math.pi
-                    
+
                     local spawn_position = {
                         x = chunk_position.x + math.cos(angle) * ATTACK_DISTANCE,
                         y = chunk_position.y + math.sin(angle) * ATTACK_DISTANCE
                     }
-                    
-                    local directions = {defines.direction.west, defines.direction.north, defines.direction.east, defines.direction.south}
+
+                    local directions = { defines.direction.west, defines.direction.north, defines.direction.east, defines
+                        .direction.south }
                     local dir_index = math.floor((angle + math.pi / 4) / (math.pi / 2)) % 4 + 1
 
                     log(angle)
@@ -52,17 +53,17 @@ script.on_nth_tick(1200, function()
                         position = arrakis.find_non_colliding_position(
                             WORM, spawn_position, 50, 1
                         ),
-                        direction=directions[dir_index],
-                        force="enemy"
+                        direction = directions[dir_index],
+                        force = "enemy"
                     })
                 end
             end
         end
 
-        local worms = arrakis.find_entities_filtered{name=WORM}
+        local worms = arrakis.find_entities_filtered { name = WORM }
         if table_size(worms) > 0 then
             for _, worm in pairs(worms) do
-                local position = {x = worm.position.x, y = worm.position.y}
+                local position = { x = worm.position.x, y = worm.position.y }
                 local pollution = arrakis.get_pollution(position)
                 local uuid = worm.unit_number
 
@@ -104,7 +105,8 @@ local function find_spice_blow_positions(surface, chance_per_chunk)
 
             for _, player in pairs(game.players) do
                 if player.surface == surface then
-                    player.add_custom_alert(blow_pos, {type="item", name="spice"}, {"", "Spice Blow immanent"}, true)
+                    player.add_custom_alert(blow_pos, { type = "item", name = "spice" }, { "", "Spice Blow immanent" },
+                        true)
                 end
             end
 
@@ -134,10 +136,10 @@ local function spawn_spice_blow(surface, ore_name, ore_amount, radius)
 
         for dx = -radius, radius do
             for dy = -radius, radius do
-                local dist_squared = dx * dx + dy * dy  
-                if dist_squared <= radius * radius then  
+                local dist_squared = dx * dx + dy * dy
+                if dist_squared <= radius * radius then
                     local ore_position = { x = position.x + dx, y = position.y + dy }
-                    if math.random() < 0.6 then 
+                    if math.random() < 0.6 then
                         surface.create_entity({
                             name = ore_name,
                             position = ore_position,
@@ -149,25 +151,23 @@ local function spawn_spice_blow(surface, ore_name, ore_amount, radius)
         end
     end
     storage.spice_blow_positions = {}
-
 end
 
-script.on_init(function ()
+script.on_init(function()
     storage.spice_blow_positions = {}
 end)
 
 -- frequency of new spice blows, 15 min
 local frequency = 15 * 60 * 60
-script.on_event(defines.events.on_tick, function(event) 
+script.on_event(defines.events.on_tick, function(event)
     -- Choose new spice blow locations
     if event.tick % frequency == 0 then
         find_spice_blow_positions(game.surfaces["arrakis"], 0.001)
     end
     -- Spawn the spice blow 30s later
-    if event.tick % frequency == 1800 then 
+    if event.tick % frequency == 1800 then
         spawn_spice_blow(game.surfaces["arrakis"], "spice-ore", 3000, 10)
     end
-    
 end)
 
 
@@ -185,13 +185,13 @@ script.on_event(defines.events.on_built_entity, function(event)
 
     -- Calculate output position based on direction
     local offset = {
-        [defines.direction.north] = {x = 0, y = -3},
-        [defines.direction.east]  = {x = 2, y = 0},
-        [defines.direction.south] = {x = 0, y = 2},
-        [defines.direction.west]  = {x = -3, y = 0}
+        [defines.direction.north] = { x = 0, y = -3 },
+        [defines.direction.east]  = { x = 2, y = 0 },
+        [defines.direction.south] = { x = 0, y = 2 },
+        [defines.direction.west]  = { x = -3, y = 0 }
     }
 
-    local delta = offset[direction] or {x = 0, y = 1}  -- default to south
+    local delta = offset[direction] or { x = 0, y = 1 } -- default to south
     local chest_position = {
         x = output_position.x + delta.x,
         y = output_position.y + delta.y
@@ -223,13 +223,13 @@ script.on_event(defines.events.on_built_entity, function(event)
 
     -- Calculate output position based on direction
     local offset = {
-        [defines.direction.north] = {x = 0, y = -3},
-        [defines.direction.east]  = {x = 2, y = 0},
-        [defines.direction.south] = {x = 0, y = 2},
-        [defines.direction.west]  = {x = -3, y = 0}
+        [defines.direction.north] = { x = 0, y = -3 },
+        [defines.direction.east]  = { x = 2, y = 0 },
+        [defines.direction.south] = { x = 0, y = 2 },
+        [defines.direction.west]  = { x = -3, y = 0 }
     }
 
-    local delta = offset[direction] or {x = 0, y = 1}  -- default to south
+    local delta = offset[direction] or { x = 0, y = 1 } -- default to south
     local chest_position = {
         x = output_position.x + delta.x,
         y = output_position.y + delta.y
@@ -254,12 +254,12 @@ script.on_event(defines.events.on_pre_player_mined_item, function(event)
 
     if entity.name == "stationary-spice-harvester" then
         local offset = {
-            [defines.direction.north] = {x = 0, y = -2.5},
-            [defines.direction.east]  = {x = 2.5, y = 0},
-            [defines.direction.south] = {x = 0, y = 2.5},
-            [defines.direction.west]  = {x = -2.5, y = 0}
+            [defines.direction.north] = { x = 0, y = -2.5 },
+            [defines.direction.east]  = { x = 2.5, y = 0 },
+            [defines.direction.south] = { x = 0, y = 2.5 },
+            [defines.direction.west]  = { x = -2.5, y = 0 }
         }
-        local delta = offset[entity.direction] or {x = 0, y = 1}
+        local delta = offset[entity.direction] or { x = 0, y = 1 }
         local chest_position = {
             x = entity.position.x + delta.x,
             y = entity.position.y + delta.y
@@ -269,37 +269,43 @@ script.on_event(defines.events.on_pre_player_mined_item, function(event)
 
         local player = game.get_player(event.player_index)
 
-        local chests = surface.find_entities_filtered{
+        local chests = surface.find_entities_filtered {
             position = chest_position,
             name = "steel-chest"
         }
 
         if player == nil then return end
 
-
         for _, chest in pairs(chests) do
-            if chest and chest.valid and chest.get_inventory(defines.inventory.chest) then
-                local chest_inv = chest.get_inventory(defines.inventory.chest).get_contents()
+            if chest and chest.valid then
+                local inv = chest.get_inventory(defines.inventory.chest)
+                if inv and inv.valid then
+                    local contents = inv.get_contents()
+                    local player_inv = player.get_main_inventory()
 
-                for i = 1, table_size(chest_inv) do
-                    local stack = chest_inv[i]
-                    if stack then
-                        -- Try to insert into player's inventory
-                        local inserted = player.get_main_inventory().insert(stack)
-                        player.create_local_flying_text{text={"", "+", stack.count, " ", {"item-name." .. stack.name}}, create_at_cursor=true}
-                        if inserted < stack.count then
-                            -- Drop the rest on the ground
-                            surface.spill_item_stack(player.position, {name = stack.name, count = stack.count - inserted}, true)
+                    for _, content in pairs(contents) do
+                        if content then
+                            local inserted = player_inv.insert({
+                                name = content.name,
+                                count = content.count,
+                                quality = content.quality
+                            })
+                            if inserted and inserted > 0 then
+                                player.create_local_flying_text {
+                                    text = { "", "+", inserted, " ", { "item-name." .. content.name } },
+                                    create_at_cursor = true
+                                }
+                            end
+                            if type(inserted) == "number" and inserted < content.count then
+                                surface.spill_item_stack({ position = player.position, stack = { name = content.name, count = content.count - inserted } })
+                            end
                         end
                     end
                 end
-
                 chest.destroy()
             end
         end
-
     else
-        return 
+        return
     end
-
 end)

--- a/control.lua
+++ b/control.lua
@@ -1,6 +1,10 @@
 require("prototypes.function")
 
 local WORM = "big-sandworm"
+local POLLUTION_THRESHOLD = 15
+local ATTACK_DISTANCE = 90
+local worm_brain = {}
+
 
 local function already_attacked(surface, position, radius)
     local worms = surface.find_entities_filtered { name = WORM }
@@ -17,10 +21,6 @@ local function already_attacked(surface, position, radius)
 
     return false
 end
-
-local POLLUTION_THRESHOLD = 15
-local ATTACK_DISTANCE = 90
-local worm_brain = {}
 
 
 script.on_nth_tick(1200, function()
@@ -40,7 +40,8 @@ script.on_nth_tick(1200, function()
                         y = chunk_position.y + math.sin(angle) * ATTACK_DISTANCE
                     }
 
-                    local directions = { defines.direction.west, defines.direction.north, defines.direction.east, defines.direction.south }
+                    local directions = { defines.direction.west, defines.direction.north, defines.direction.east, defines
+                        .direction.south }
                     local dir_index = math.floor((angle + math.pi / 4) / (math.pi / 2)) % 4 + 1
 
                     log(angle)
@@ -103,7 +104,12 @@ local function find_spice_blow_positions(surface, chance_per_chunk)
 
             for _, player in pairs(game.players) do
                 if player.surface == surface then
-                    player.add_custom_alert(blow_pos, { type = "item", name = "spice" }, { "", "Spice Blow immanent" }, true)
+                    player.add_custom_alert(
+                        blow_pos,
+                        { type = "item", name = "spice" },
+                        { "", "Spice Blow immanent" },
+                        true
+                    )
                 end
             end
 
@@ -265,21 +271,21 @@ script.on_event(defines.events.on_pre_player_mined_item, function(event)
         local surface = entity.surface
 
         local player = game.get_player(event.player_index)
+        if not player then return end
+
+        local player_inv = player.get_main_inventory()
+        if not player_inv then return end
 
         local chests = surface.find_entities_filtered {
             position = chest_position,
             name = "steel-chest"
         }
 
-        if player == nil then return end
-
         for _, chest in pairs(chests) do
             if chest and chest.valid then
-                local inv = chest.get_inventory(defines.inventory.chest)
-                if inv and inv.valid then
-                    local contents = inv.get_contents()
-                    local player_inv = player.get_main_inventory()
-
+                local chest_inv = chest.get_inventory(defines.inventory.chest)
+                if chest_inv and chest_inv.valid then
+                    local contents = chest_inv.get_contents()
                     for _, content in pairs(contents) do
                         if content then
                             local inserted = player_inv.insert({
@@ -294,7 +300,14 @@ script.on_event(defines.events.on_pre_player_mined_item, function(event)
                                 }
                             end
                             if type(inserted) == "number" and inserted < content.count then
-                                surface.spill_item_stack({ position = player.position, stack = { name = content.name, count = content.count - inserted, quality = content.quality } })
+                                surface.spill_item_stack({
+                                    position = player.position,
+                                    stack = {
+                                        name = content.name,
+                                        count = content.count - inserted,
+                                        quality = content.quality
+                                    }
+                                })
                             end
                         end
                     end
@@ -302,7 +315,5 @@ script.on_event(defines.events.on_pre_player_mined_item, function(event)
                 chest.destroy()
             end
         end
-    else
-        return
     end
 end)

--- a/control.lua
+++ b/control.lua
@@ -40,8 +40,13 @@ script.on_nth_tick(1200, function()
                         y = chunk_position.y + math.sin(angle) * ATTACK_DISTANCE
                     }
 
-                    local directions = { defines.direction.west, defines.direction.north, defines.direction.east, defines
-                        .direction.south }
+                    local directions = {
+                        defines.direction.west,
+                        defines.direction.north,
+                        defines.direction.east,
+                        defines.direction.south
+                    }
+
                     local dir_index = math.floor((angle + math.pi / 4) / (math.pi / 2)) % 4 + 1
 
                     log(angle)

--- a/prototypes/entity/spice-harvester.lua
+++ b/prototypes/entity/spice-harvester.lua
@@ -199,7 +199,7 @@ local stationary_spice_harvester = {
     icon = "__base__/graphics/icons/electric-mining-drill.png",
     icon_size = 64,
     flags = {"placeable-neutral", "player-creation"},
-    minable = {mining_time = 1, result = "iron-plate"},
+    minable = {mining_time = 1, result = "stationary-spice-harvester"},
     max_health = 400,
     corpse = "electric-mining-drill-remnants",
     dying_explosion = "electric-mining-drill-explosion",


### PR DESCRIPTION
1. Prevent crash when player inventory overflows.
2. Return stationary spice harvester when mined.
